### PR TITLE
check for echo.Map (introduced in v3)

### DIFF
--- a/pongor.go
+++ b/pongor.go
@@ -65,6 +65,10 @@ func getContext(templateData interface{}) pongo2.Context {
 	if isMap {
 		return contextData
 	}
+    contextData, isEchoMap := templateData.(echo.Map)
+    if isEchoMap {
+        return contextData
+    }
 	return nil
 }
 


### PR DESCRIPTION
Using echo v3 i came across the problem of variables not passed through to the template. 

this was the case because of the lines 65-67 checking if the params are passed as a map-string-interface, where in echo v3 you are encouraged to use the echo.Map-shortcut.